### PR TITLE
reset slot signal before tx wait

### DIFF
--- a/esp32-wifi-hal-rs/src/wmac.rs
+++ b/esp32-wifi-hal-rs/src/wmac.rs
@@ -627,6 +627,7 @@ impl<'res> WiFi<'res> {
         }
         impl CancelOnDrop<'_> {
             async fn wait_for_tx_complete(&self) -> WiFiResult<()> {
+                WIFI_TX_SLOTS[self.slot].reset();
                 // Wait for the hardware to confirm transmission.
                 let res = match WIFI_TX_SLOTS[self.slot].wait().await {
                     TxSlotStatus::Done => Ok(()),


### PR DESCRIPTION
under unknown situations it seems possible for the slot signal to get out of sync causing transmit.await to instantly return and not wait for the interupt, this works around the problem by reseting the slot signal before waiting on tx

